### PR TITLE
Add proper docker environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+docker-compose.yml
+.rssh.yml
+LICENCE
+README.md

--- a/cmd/rssh.go
+++ b/cmd/rssh.go
@@ -84,6 +84,7 @@ func Execute() {
 		TimeFormat: time.RFC3339,
 		NoColor:    !terminal.IsTerminal(int(os.Stdout.Fd())),
 	})
+	viper.SetEnvPrefix("rssh")
 	viper.AutomaticEnv()
 
 	if err := NewCommand().Execute(); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  etcd:
+    image: quay.io/coreos/etcd
+    environment:
+      ETCD_LISTEN_CLIENT_URLS: 'http://0.0.0.0:2379'
+      ETCD_ADVERTISE_CLIENT_URLS: 'http://0.0.0.0:2379'
+    restart: on-failure
+  rssh_server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: xide/rssh
+    environment:
+      RSSH_ETCD: 'http://etcd:2379'
+      RSSH_ADDR: '0.0.0.0'
+      RSSH_PORT: '2222'
+    command: server
+    depends_on:
+      - etcd
+    ports:
+      - 2222:2222

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,12 @@ services:
       dockerfile: Dockerfile
     image: xide/rssh
     environment:
-      RSSH_ETCD: 'http://etcd:2379'
-      RSSH_ADDR: '0.0.0.0'
-      RSSH_PORT: '2222'
+      RSSH_ETCD_ENDPOINTS: 'http://etcd:2379'
+      RSSH_API_ADDR: '0.0.0.0'
+      RSSH_API_PORT: '2222'
     command: server
     depends_on:
       - etcd
     ports:
       - 2222:2222
+      - 9321:9321


### PR DESCRIPTION
- Add `docker-compose` file with `etcd` daemon
- Cleanup `Dockerfile` with multi-stage builds
- Golang `mod` and `sum` for docker cache
- "pin" base docker image version
- Set `viper` env prefix to `rssh`
